### PR TITLE
fixed mispelled package in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Nominatim (from the Latin, 'by name') is a tool to search osm data by name and a
 ## Usage
 
   ```python
-  import pynominatim
-  client = pynominatim.create()
+  import pyNominatim
+  client = pyNominatim.create()
   ```
 
 ### Search


### PR DESCRIPTION
The how-to section in the readme had a misspelled package name. i just changed the doc.
